### PR TITLE
Update `__all__` to include `vfsopen` and `vfspath`

### DIFF
--- a/pathlib_abc/__init__.py
+++ b/pathlib_abc/__init__.py
@@ -23,7 +23,7 @@ except ImportError:
         return encoding
 
 
-__all__ = ['PathParser', 'PathInfo', 'JoinablePath', 'ReadablePath', 'WritablePath', 'magic_open']
+__all__ = ['PathParser', 'PathInfo', 'JoinablePath', 'ReadablePath', 'WritablePath', 'vfsopen', 'vfspath']
 
 
 def _explode_path(path, split):


### PR DESCRIPTION
Hi @barneygale,

I just merged a PR to update universal-pathlib to pathlib-abc==0.5.0 for the next release, and I noticed that `pathlib_abc.__all__` wasn't updated with `vfsopen` and `vfspath`.

Cheers,
Andreas ☺️ 