### PR TITLE
Sync from upstream

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Version History
 Unreleased
 ----------
 
-- Nothing yet
+- Make ``vfsopen()`` try to call ``open()``, like it did before 0.5.0.
 
 v0.5.0
 ------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,7 +20,7 @@ This package offers the following functions:
                       encoding=None, errors=None, newline=None)
 
     Open the given object and return a file object. Unlike the built-in
-    ``open()`` function, this function calls the object's
+    ``open()`` function, this function additionally calls the object's
     :meth:`~ReadablePath.__open_reader__`,
     :meth:`~WritablePath.__open_writer__` or :meth:`!__open_updater__` method,
     as appropriate for the given mode.

--- a/pathlib_abc/_glob.py
+++ b/pathlib_abc/_glob.py
@@ -122,21 +122,6 @@ def _glob0(dirname, basename, dir_fd, dironly, include_hidden=False):
             return [basename]
     return []
 
-_deprecated_function_message = (
-    "{name} is deprecated and will be removed in Python {remove}. Use "
-    "glob.glob and pass a directory to its root_dir argument instead."
-)
-
-def glob0(dirname, pattern):
-    import warnings
-    warnings._deprecated("glob.glob0", _deprecated_function_message, remove=(3, 15))
-    return _glob0(dirname, pattern, None, False)
-
-def glob1(dirname, pattern):
-    import warnings
-    warnings._deprecated("glob.glob1", _deprecated_function_message, remove=(3, 15))
-    return _glob1(dirname, pattern, None, False)
-
 # This helper function recursively yields relative pathnames inside a literal
 # directory.
 

--- a/pathlib_abc/_os.py
+++ b/pathlib_abc/_os.py
@@ -210,8 +210,8 @@ def vfsopen(obj, mode='r', buffering=-1, encoding=None, errors=None,
     Open the file pointed to by this path and return a file object, as
     the built-in open() function does.
 
-    Unlike the built-in open() function, this function accepts 'openable'
-    objects, which are objects with any of these special methods:
+    Unlike the built-in open() function, this function additionally accepts
+    'openable' objects, which are objects with any of these special methods:
 
         __open_reader__()
         __open_writer__(mode)
@@ -221,19 +221,24 @@ def vfsopen(obj, mode='r', buffering=-1, encoding=None, errors=None,
     and 'x' modes; and '__open_updater__' for 'r+' and 'w+' modes. If text
     mode is requested, the result is wrapped in an io.TextIOWrapper object.
     """
-    text = 'b' not in mode
     if buffering != -1:
         raise ValueError("buffer size can't be customized")
-    elif text:
+    text = 'b' not in mode
+    if text:
         # Call io.text_encoding() here to ensure any warning is raised at an
         # appropriate stack level.
         encoding = text_encoding(encoding)
-    elif encoding is not None:
-        raise ValueError("binary mode doesn't take an encoding argument")
-    elif errors is not None:
-        raise ValueError("binary mode doesn't take an errors argument")
-    elif newline is not None:
-        raise ValueError("binary mode doesn't take a newline argument")
+    try:
+        return open(obj, mode, buffering, encoding, errors, newline)
+    except TypeError:
+        pass
+    if not text:
+        if encoding is not None:
+            raise ValueError("binary mode doesn't take an encoding argument")
+        if errors is not None:
+            raise ValueError("binary mode doesn't take an errors argument")
+        if newline is not None:
+            raise ValueError("binary mode doesn't take a newline argument")
     mode = ''.join(sorted(c for c in mode if c not in 'bt'))
     if mode == 'r':
         stream = _open_reader(obj)

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -36,6 +36,12 @@ class ReadTestBase:
             self.assertIsInstance(f, io.TextIOBase)
             self.assertEqual(f.read(), 'this is file A\n')
 
+    def test_open_r_buffering_error(self):
+        p = self.root / 'fileA'
+        self.assertRaises(ValueError, vfsopen, p, 'r', buffering=0)
+        self.assertRaises(ValueError, vfsopen, p, 'r', buffering=1)
+        self.assertRaises(ValueError, vfsopen, p, 'r', buffering=1024)
+
     @unittest.skipIf(
         not getattr(sys.flags, 'warn_default_encoding', 0),
         "Requires warn_default_encoding",

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -36,6 +36,12 @@ class WriteTestBase:
             f.write('this is file A\n')
         self.assertEqual(self.ground.readtext(p), 'this is file A\n')
 
+    def test_open_w_buffering_error(self):
+        p = self.root / 'fileA'
+        self.assertRaises(ValueError, vfsopen, p, 'w', buffering=0)
+        self.assertRaises(ValueError, vfsopen, p, 'w', buffering=1)
+        self.assertRaises(ValueError, vfsopen, p, 'w', buffering=1024)
+
     @unittest.skipIf(
         not getattr(sys.flags, 'warn_default_encoding', 0),
         "Requires warn_default_encoding",


### PR DESCRIPTION
Restore call to `open()` in `vfsopen()`. 

Fixes #43